### PR TITLE
fix: require Node >=18 in engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "musescore"
   ],
   "type": "module",
+  "engines": { "node": ">=18" },
   "typings": "./typings/mscx2ly.d.ts",
   "author": "Maurits Lamers",
   "license": "MIT",


### PR DESCRIPTION
Fixes #1

## Problem
When installed on Node 12, the tool failed with `ERR_UNKNOWN_FILE_EXTENSION` because Node 12 does not support ES modules. There was no upfront warning about this incompatibility.

## Fix
Added an `engines` field to `package.json` specifying `"node": ">=18"`. npm will now warn users at install time if their Node version is too old, before they even try to run the tool.