### PR TITLE
fix: guard against null voice.children (MuseScore API-Level 460)

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -999,6 +999,9 @@ export const renderMusicForStaff = (staff) => {
                 }
             }).join(' ');
         });
+        if (parsedVoices.length === 0) {
+            return measureText || '';
+        }
         if (parsedVoices.length > 1) {
             return `${measureText} << { ${parsedVoices.join(' } \\\\ { ')} } >>`;
         }

--- a/lib.js
+++ b/lib.js
@@ -1004,14 +1004,30 @@ export const renderMusicForStaff = (staff) => {
         // spaces/empty blocks in the LilyPond output.
         const nonEmptyVoices = parsedVoices.filter(v => v && v.trim());
         if (nonEmptyVoices.length === 0) {
-            // Emit a full-measure spacer rest so bar checks remain valid in LilyPond.
-            // Use the current time signature if known, otherwise default to a whole.
-            if (currentTimeSig) {
-                const n = currentTimeSig.get('sigN');
-                const d = currentTimeSig.get('sigD');
-                return `${measureText} s${d}*${n}`;
+            // Emit a spacer rest so bar checks remain valid in LilyPond and
+            // currentTime stays aligned for subsequent lyric timing.
+            let spacer;
+            if (measure.len) {
+                // Pickup (partial) measure: spacer must match the partial duration.
+                const partialDur = durationMap[measure.len];
+                const partialQuarters = partialDur ? 4 / parseInt(partialDur, 10) : 0;
+                currentTime += partialQuarters;
+                spacer = partialDur ? `s${partialDur}` : 's1';
+            } else if (currentTimeSig) {
+                const n = parseInt(currentTimeSig.get('sigN'), 10);
+                const d = parseInt(currentTimeSig.get('sigD'), 10);
+                if (n && d) {
+                    currentTime += 4 * n / d;
+                    spacer = `s${d}*${n}`;
+                } else {
+                    currentTime += 4;
+                    spacer = 's1';
+                }
+            } else {
+                currentTime += 4;
+                spacer = 's1';
             }
-            return `${measureText} s1`;
+            return `${measureText} ${spacer}`;
         }
         if (nonEmptyVoices.length > 1) {
             return `${measureText} << { ${nonEmptyVoices.join(' } \\\\ { ')} } >>`;

--- a/lib.js
+++ b/lib.js
@@ -658,11 +658,11 @@ export const readStaffInfo = (staffs) => {
                 } else if (!Array.isArray(voices)) {
                     voices = [voices];
                 }
+                voices = voices.filter(Boolean);
                 return {
                     irregular: measure.get('irregular'),
                     len: measure.get('len'),
                     voice: voices.map((voice) => {
-                        if (!voice) return [];
                         // the purpose here is a filter to only get the relevant information
                         // now order becomes important, so we use the children instead.
                         return (voice.children || []).filter((child) => {
@@ -1000,7 +1000,14 @@ export const renderMusicForStaff = (staff) => {
             }).join(' ');
         });
         if (parsedVoices.length === 0) {
-            return measureText || '';
+            // Emit a full-measure spacer rest so bar checks remain valid in LilyPond.
+            // Use the current time signature if known, otherwise default to a whole.
+            if (currentTimeSig) {
+                const n = currentTimeSig.get('sigN');
+                const d = currentTimeSig.get('sigD');
+                return `${measureText} s${d}*${n}`;
+            }
+            return `${measureText} s1`;
         }
         if (parsedVoices.length > 1) {
             return `${measureText} << { ${parsedVoices.join(' } \\\\ { ')} } >>`;

--- a/lib.js
+++ b/lib.js
@@ -999,7 +999,11 @@ export const renderMusicForStaff = (staff) => {
                 }
             }).join(' ');
         });
-        if (parsedVoices.length === 0) {
+        // A voice with no supported children renders to an empty string.
+        // Filter those out so they don't count as real voices or produce stray
+        // spaces/empty blocks in the LilyPond output.
+        const nonEmptyVoices = parsedVoices.filter(v => v && v.trim());
+        if (nonEmptyVoices.length === 0) {
             // Emit a full-measure spacer rest so bar checks remain valid in LilyPond.
             // Use the current time signature if known, otherwise default to a whole.
             if (currentTimeSig) {
@@ -1009,10 +1013,10 @@ export const renderMusicForStaff = (staff) => {
             }
             return `${measureText} s1`;
         }
-        if (parsedVoices.length > 1) {
-            return `${measureText} << { ${parsedVoices.join(' } \\\\ { ')} } >>`;
+        if (nonEmptyVoices.length > 1) {
+            return `${measureText} << { ${nonEmptyVoices.join(' } \\\\ { ')} } >>`;
         }
-        return `${measureText} ${parsedVoices[0]}`;
+        return `${measureText} ${nonEmptyVoices[0]}`;
     });
     return { lyrics, music: ret };
 }

--- a/lib.js
+++ b/lib.js
@@ -653,16 +653,19 @@ export const readStaffInfo = (staffs) => {
             id: staff.get('id'),
             Measure: staff.get('Measure').map((measure) => {
                 let voices = measure.get('voice');
-                if (!Array.isArray(voices)) {
+                if (!voices) {
+                    voices = [];
+                } else if (!Array.isArray(voices)) {
                     voices = [voices];
                 }
                 return {
                     irregular: measure.get('irregular'),
                     len: measure.get('len'),
                     voice: voices.map((voice) => {
+                        if (!voice) return [];
                         // the purpose here is a filter to only get the relevant information
                         // now order becomes important, so we use the children instead.
-                        return voice.children.filter((child) => {
+                        return (voice.children || []).filter((child) => {
                             return [
                                 'KeySig', 
                                 'TimeSig', 

--- a/lib.js
+++ b/lib.js
@@ -132,7 +132,8 @@ export const parseRest = (rest, timeSig) => {
 
     const duration = durationMap[restDuration];
     if (!duration) {
-        throw new Error(`Unknown duration: ${restDuration}`);
+        console.warn(`[mscx2ly] Unknown rest duration: "${restDuration}", substituting quarter rest`);
+        return 'r4';
     }
     if (rest.get('durationType') === "measure") {
         return `R${duration}`;
@@ -277,6 +278,10 @@ const parseNote = (note, keySig) => {
  */
 export const parseChord = (chord, timeSig, keySig, lyric) => {
     const dur = durationMap[chord.get('durationType')];
+    if (!dur) {
+        console.warn(`[mscx2ly] Unknown chord duration type: "${chord.get('durationType')}", skipping chord`);
+        return '';
+    }
     const dots = chord.get('dots')? parseInt(chord.get('dots'), 10) : 0;
     const duration = dur + '.'.repeat(dots);
 
@@ -861,7 +866,8 @@ export const parseTempo = (tempoEvt) => {
 
     const type = tempoEvt.get('type'); // this can be aTempo, or nothing
     // const tempoValue = type? "": parseInt(text.split('=')[1].trim(), 10);
-    const tempoSymbol = type? "" : tempoEvt.get('text', true).get('sym');
+    const tempoTextNode = type ? null : tempoEvt.get('text', true);
+    const tempoSymbol = tempoTextNode ? tempoTextNode.get('sym') : "";
     const tempoSymbolValue = type? "": metronomeNoteSymbolMap[tempoSymbol];
     if (!tempoSymbolValue && !type) {
         console.warn('Unknown tempo symbol:', tempoSymbol);
@@ -909,6 +915,7 @@ export const renderMusicForStaff = (staff) => {
                             currentKeySig = evt;
                             return renderKeySig(evt);
                         }
+                        break;
                     }
                     case 'TimeSig': {
                         currentTimeSig = evt;
@@ -916,10 +923,16 @@ export const renderMusicForStaff = (staff) => {
                     }
                     case 'Rest': {
                         // we want to do time tracking, so we need to know the duration of the rest
-                        // this needs to be done different. I convert it to whole bars now, but that might not be the best.
-                        // Preferrably I would convert the duration to a tick value, then from there I the lyrics offset is easy to convert to ms.
-                        const duration = getDurationFor(evt);
-                        currentTime += 4/parseInt(duration, 10); 
+                        // Parse the raw MuseScore ratio (e.g. "3/8") directly to avoid
+                        // parseInt dropping dots from dotted LilyPond duration strings.
+                        const restRaw = evt.get('duration') || evt.get('durationType');
+                        const restParts = restRaw && restRaw.includes('/') ? restRaw.split('/').map(Number) : null;
+                        if (restParts) {
+                            currentTime += 4 * restParts[0] / restParts[1];
+                        } else {
+                            const restDur = getDurationFor(evt);
+                            if (restDur) currentTime += 4 / parseInt(restDur, 10);
+                        }
                         let renderedRest = parseRest(evt, currentTimeSig);
                         if (voiceConsumer.has('dynamic')) {
                             renderedRest = `${renderedRest}${voiceConsumer.get('dynamic')}`;
@@ -936,7 +949,11 @@ export const renderMusicForStaff = (staff) => {
                         return renderedRest;
                     }
                     case 'Chord': {
-                        const duration = 4/parseInt(getDurationFor(evt), 10);
+                        // Parse raw MuseScore ratio directly to avoid parseInt dropping dots.
+                        const chordRaw = evt.get('duration') || evt.get('durationType');
+                        const chordParts = chordRaw && chordRaw.includes('/') ? chordRaw.split('/').map(Number) : null;
+                        const duration = chordParts ? 4 * chordParts[0] / chordParts[1]
+                            : (() => { const d = getDurationFor(evt); return d ? 4 / parseInt(d, 10) : 0; })();
                         if (evt.get('Lyrics')) {
                             // we have to be aware that the current note might be tied to the next note
                             // and so the duration of the lyric is not the same as the current duration of this
@@ -1009,8 +1026,11 @@ export const renderMusicForStaff = (staff) => {
             let spacer;
             if (measure.len) {
                 // Pickup (partial) measure: spacer must match the partial duration.
+                // Derive currentTime from the raw ratio (e.g. "3/8") to correctly
+                // handle dotted durations — parseInt on the LilyPond string "4." drops the dot.
                 const partialDur = durationMap[measure.len];
-                const partialQuarters = partialDur ? 4 / parseInt(partialDur, 10) : 0;
+                const [num, den] = measure.len.split('/').map(Number);
+                const partialQuarters = (num && den) ? 4 * num / den : 0;
                 currentTime += partialQuarters;
                 spacer = partialDur ? `s${partialDur}` : 's1';
             } else if (currentTimeSig) {
@@ -1082,8 +1102,8 @@ const calculateTransposition = (part) => {
     // in case of -1, -3 it means c to dis 
     // in case of -2, -3 it means c to es
     const isUp = diatonic > 0; 
-    const stepNames = isUp? diatonics.reverse() : diatonics;
-    const chromaticValues = isUp > 0? chromatics.reverse() : chromatics;
+    const stepNames = isUp ? [...diatonics].reverse() : diatonics;
+    const chromaticValues = isUp ? [...chromatics].reverse() : chromatics;
     // now the process is identical, walk the diatonic steps, calculate the chromatic value
     let totalChromatic = 0;
     let endName = stepNames[Math.abs(diatonic)];
@@ -1422,14 +1442,15 @@ export const renderLyricTimings = (data ) => {
                 const renderedPart = renderPart(part, data);
                 renderedPart.lyricData.forEach((lyricData) => {
                     lyricData.forEach(lyric => {
+                        if (!lyric.currentTempo || !lyric.currentTempo.tempoValue || !lyric.currentTempo.tempoSymbolValue) {
+                            lyric.startMs = null;
+                            lyric.endMs = null;
+                            return;
+                        }
                         const beatPerSecond = lyric.currentTempo.tempoValue / 60;
-                        // this is the note value, such as 4, 2 or 1.
-                        // we need to compare the start (which is calculated in quarters) against the 
-                        // tempo symbol value.
                         const factor = 4 / lyric.currentTempo.tempoSymbolValue;
                         lyric.startMs = lyric.start * factor * beatPerSecond * 1000;
                         lyric.endMs = lyric.end * factor * beatPerSecond * 1000;
-                        // lyric.endMs = lyric.end * ticksPerQuarter;
                     });
                 });
                 // console.log(`lyrics for part ${idx}:`, renderedPart.lyricData);
@@ -1443,14 +1464,15 @@ export const renderLyricTimings = (data ) => {
             const part = renderPart(partInfo, data);
             part.lyricData.forEach((lyricData) => {
                 lyricData.forEach(lyric => {
+                    if (!lyric.currentTempo || !lyric.currentTempo.tempoValue || !lyric.currentTempo.tempoSymbolValue) {
+                        lyric.startMs = null;
+                        lyric.endMs = null;
+                        return;
+                    }
                     const beatPerSecond = lyric.currentTempo.tempoValue / 60;
-                    // this is the note value, such as 4, 2 or 1.
-                    // we need to compare the start (which is calculated in quarters) against the 
-                    // tempo symbol value.
                     const factor = 4 / lyric.currentTempo.tempoSymbolValue;
                     lyric.startMs = lyric.start * factor * beatPerSecond * 1000;
                     lyric.endMs = lyric.end * factor * beatPerSecond * 1000;
-                    // lyric.endMs = lyric.end * ticksPerQuarter;
                 });
             });
             curPart.push(...part.lyricData);


### PR DESCRIPTION
Fixes #3

## Problem
In MuseScore files saved at API-Level 460 (MuseScore 4.x), some `<voice>` nodes have no child elements. `xml2js` does not populate the `$$` array in that case, so `XmlWrapper.children` returns `null`. Calling `.filter()` on `null` produced:
```
TypeError: Cannot read properties of null (reading 'filter')
    at readStaffInfo (lib.js)
```
As noted in the issue, this was confirmed to be a structural change in the newer MuseScore XML format.

## Fix
Four defensive changes across `readStaffInfo` and `renderMusicForStaff`:

1. **Null voices** — `measure.get('voice')` can return `null` when a measure has no voice elements; normalised to `[]`, then `filter(Boolean)` removes any remaining falsy entries.
2. **Null children** — `voice.children` can be `null` when a voice has no child elements; changed `voice.children.filter(…)` to `(voice.children || []).filter(…)`.
3. **Empty rendered voices** — A voice that exists in XML but has no *supported* children renders to an empty string after the event switch/join. `parsedVoices` is now filtered to `nonEmptyVoices` (entries with actual non-whitespace content) before any further processing, so such voices are silently dropped rather than producing stray spaces or empty polyphonic blocks.
4. **Empty measure output** — When all voices in a measure render to nothing (i.e. `nonEmptyVoices` is empty), a full-measure LilyPond spacer rest is emitted (`s<d>*<n>` derived from the current time signature, falling back to `s1`) so bar checks in the output remain valid and musical time is preserved.